### PR TITLE
chore: html returning reports should be returned as a byte array instead of a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,8 @@ public class CrdaExample {
         // instantiate the Crda API implementation
         var crdaApi = new CrdaApi();
 
-        // get a String future holding a html report
-        CompletableFuture<String> htmlReport = crdaApi.stackAnalysisHtmlAsync("/path/to/pom.xml");
+        // get a byte array future holding a html report
+        CompletableFuture<byte[]> htmlReport = crdaApi.stackAnalysisHtmlAsync("/path/to/pom.xml");
 
         // get a AnalysisReport future holding a deserialized report
         CompletableFuture<AnalysisReport> analysisReport = crdaApi.stackAnalysisAsync("/path/to/pom.xml");

--- a/src/it/simple-modular/src/main/java/simple/modular/ApiWrapper.java
+++ b/src/it/simple-modular/src/main/java/simple/modular/ApiWrapper.java
@@ -25,7 +25,7 @@ public final class ApiWrapper {
     this.crdaApi = crdaApi;
   }
 
-  public String getAnalysisHtml(final String manifestPath) throws Exception {
+  public byte[] getAnalysisHtml(final String manifestPath) throws Exception {
     return crdaApi.stackAnalysisHtmlAsync(manifestPath).get();
   }
 

--- a/src/it/simple-modular/src/test/java/simple/modular/Simple_Integration_Test.java
+++ b/src/it/simple-modular/src/test/java/simple/modular/Simple_Integration_Test.java
@@ -54,7 +54,7 @@ class Simple_Integration_Test {
   @Test
   void test_stack_analysis_html_report() throws Exception {
     // load the pre-configured expected html response
-    var expectedHtmlAnalysis = Files.readString(Paths.get("src/test/resources/it_poms/response.html"));
+    var expectedHtmlAnalysis = Files.readAllBytes(Paths.get("src/test/resources/it_poms/response.html"));
     if (mockRealAPI) {
       // mock a http response object and stub it to return the expected html report as a body
       var mockHtmlResponse = mock(HttpResponse.class);

--- a/src/main/java/com/redhat/crda/Api.java
+++ b/src/main/java/com/redhat/crda/Api.java
@@ -29,7 +29,7 @@ public interface Api {
    * @return the HTML report as a String wrapped in a CompletableFuture
    * @throws IOException when failed to load the manifest file
    */
-  CompletableFuture<String> stackAnalysisHtmlAsync(String manifestFile) throws IOException;
+  CompletableFuture<byte[]> stackAnalysisHtmlAsync(String manifestFile) throws IOException;
 
   /**
    * Use for creating a stack analysis deserialized Json report for a given manifest file.

--- a/src/main/java/com/redhat/crda/impl/CrdaApi.java
+++ b/src/main/java/com/redhat/crda/impl/CrdaApi.java
@@ -48,9 +48,9 @@ public final class CrdaApi implements Api {
   }
 
   @Override
-  public CompletableFuture<String> stackAnalysisHtmlAsync(final String manifestFile) throws IOException {
+  public CompletableFuture<byte[]> stackAnalysisHtmlAsync(final String manifestFile) throws IOException {
     return this.client
-      .sendAsync(this.buildRequest(manifestFile, "text/html"), HttpResponse.BodyHandlers.ofString())
+      .sendAsync(this.buildRequest(manifestFile, "text/html"), HttpResponse.BodyHandlers.ofByteArray())
       .thenApply(HttpResponse::body);
   }
 

--- a/src/test/java/com/redhat/crda/impl/Crda_Api_Test.java
+++ b/src/test/java/com/redhat/crda/impl/Crda_Api_Test.java
@@ -73,7 +73,7 @@ class Crda_Api_Test {
 
     // mock and http response object and stub it to return a fake body
     var mockHttpResponse = mock(HttpResponse.class);
-    given(mockHttpResponse.body()).willReturn("<html>hello-crda</html>");
+    given(mockHttpResponse.body()).willReturn("<html>hello-crda</html>".getBytes());
 
     // mock static getManifest utility function
     try(var ecosystemTool = mockStatic(Ecosystem.class)) {
@@ -87,7 +87,7 @@ class Crda_Api_Test {
       // when invoking the api for a html stack analysis report
       var htmlTxt = crdaApiSut.stackAnalysisHtmlAsync(tmpFile.toString());
       // verify we got the correct html response
-      then(htmlTxt.get()).isEqualTo("<html>hello-crda</html>");
+      then(htmlTxt.get()).isEqualTo("<html>hello-crda</html>".getBytes());
     }
     // cleanup
     Files.deleteIfExists(tmpFile);


### PR DESCRIPTION
Signed-off-by: Tomer Figenblat <tfigenbl@redhat.com>

## Description

> Describe what you did and why.

**Related issue (if any):** fixes #issue_number_goes_here

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
